### PR TITLE
Use Go 1.11 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS build-env
+FROM golang:1.11-alpine AS build-env
 
 WORKDIR /go/src/github.com/arnested/systemd-state
 COPY *.go  /go/src/github.com/arnested/systemd-state/


### PR DESCRIPTION
Must wait for docker-library/official-images#4779 to be merged and published on [Docker Hub](https://hub.docker.com/r/library/golang/).