### PR TITLE
Use github.com/golang/gddo/httputil instead of bitbucket.org/ww/goautoneg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 
-RUN apk --no-cache add git=~2.20 mercurial=~4.8
+RUN apk --no-cache add git=~2.20
 
 COPY *.go go.mod go.sum /build/
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/arnested/systemd-state
 go 1.12
 
 require (
-	bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c
 	github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142
-	github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f
+	github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f // indirect
+	github.com/golang/gddo v0.0.0-20190312205958-5a2505f3dbf0
+	github.com/google/go-cmp v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
-bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c h1:t+Ra932MCC0eeyD/vigXqMbZTzgZjd4JOfBJWC6VSMI=
-bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c/go.mod h1:1vhO7Mn/FZMgOgDVGLy5X1mE6rq1HbkBdkF/yj8zkcg=
 github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142 h1:3jFq2xL4ZajGK4aZY8jz+DAF0FHjI51BXjjSwCzS1Dk=
 github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f h1:zlOR3rOlPAVvtfuxGKoghCmop5B0TRyu/ZieziZuGiM=
 github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/golang/gddo v0.0.0-20190312205958-5a2505f3dbf0 h1:CfaPdCDbZu8jSwjq0flJv2u+WreQM0KqytUQahZ6Xf4=
+github.com/golang/gddo v0.0.0-20190312205958-5a2505f3dbf0/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	"bitbucket.org/ww/goautoneg"
+	"github.com/golang/gddo/httputil"
 )
 
 func main() {
@@ -28,7 +28,7 @@ func main() {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	contentType := goautoneg.Negotiate(r.Header.Get("Accept"), []string{"text/html", "application/json", "text/plain"})
+	contentType := httputil.NegotiateContentType(r, []string{"text/html", "application/json", "text/plain"}, "text/plain")
 
 	// Explicitly set the Content-Type header on non-HEAD requests
 	// if the request "application/json". This is because


### PR DESCRIPTION
goautoneg gave some problems because it is hosted on Bitbucket:

* Dependabot has problems detecting it because Bitbucket has no go-import meta tag pointing to Mercurial.
* We need to also add Mercurial to the build process in Docker to be able to build.

Also it appears to not be maintained.