### PR TITLE
Add changelog to apt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
         go-version: ${{ steps.go-version.outputs.latest }}.x
         ignore-local: true
     - run: go version
+    - name: Install changelog management tool
+      run: go install github.com/goreleaser/chglog/cmd/chglog@latest
+    - name: Build changelog
+      run: chglog init
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
@@ -58,6 +62,7 @@ jobs:
     - name: apt-ftparchive release
       run: |
         apt-ftparchive -o APT::FTPArchive::Release::Origin="Arne Jørgensen" -o APT::FTPArchive::Release::Label="${{ steps.go-version.outputs.module }}" release . > Release
+        echo 'Changelogs: https://systemd-state.arnested.dk/changelog?path=@CHANGEPATH@' >> Release
         gpg -abs --no-tty --batch --yes -o - Release > Release.gpg
         gpg --clearsign --no-tty --batch --yes -o - Release > InRelease
       working-directory: site
@@ -71,6 +76,8 @@ jobs:
         sed -i "s/system-state_.*_linux_amd64.deb/<a href=\"https:\/\/github.com\/arnested\/system-state\/releases\/latest\/download\/${DEB}\">${DEB}<\/a>/" README.html
         sed -i 's/<!DOCTYPE html>//' README.html
         cat page/header.html README.html page/footer.html > site/index.html
+    - name: Add changelog to GitHub Pages
+      run: chglog format --template deb --output site/changelog
     - name: Deploy deb packages
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         cp -v dist/*.deb site/
     - name: Scan packages
       run: |
-        dpkg-scanpackages --multiversion . > Packages
+        apt-ftparchive packages . > Packages
         gzip -k -f Packages
       working-directory: site
     - name: apt-ftparchive release

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-/systemd-state
-/systemd-state.test
 /c.out
 /cc-test-reporter
+/changelog
+/changelog.yml
 /dist/
+/systemd-state
+/systemd-state.test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ nfpms:
     dependencies:
       - libsystemd0
     bindir: /usr/libexec
+    changelog: ./changelog.yml
     contents:
       - src: systemd/systemd-state.service
         dst: /lib/systemd/system/systemd-state.service


### PR DESCRIPTION
- Build and add changelog to site and package
- Use apt-ftparchive instead of dpkg-scanpackages
