### PR TITLE
Remove USER directive for container configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,4 @@ COPY $TARGETPLATFORM/systemd-state /systemd-state
 
 HEALTHCHECK CMD ["/systemd-state", "-healthcheck"]
 
-USER 65532:65532
-
 ENTRYPOINT ["/systemd-state"]


### PR DESCRIPTION
Remove USER directive from Dockerfile

We actually need to be able to read the systemd state... Doh!